### PR TITLE
Dockerfile: Optmierungen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY src ./src
 # Build the application using Maven
 RUN mvn clean package
 # Use an official OpenJDK image as the base image
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre
 # Set the working directory in the container
 WORKDIR /app
 # Copy the built JAR file from the previous stage to the container

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Formpost wird an den Keycloak zurückgeleitet. Dort werden die Userdaten verarbe
 
 Aufruf der lokalen Anwendung:
 
-    http://localhost:8443/saml
+    http://localhost:8080/saml
 
 ## Architektur
 


### PR DESCRIPTION
Im Dockerfile wird in der finalen Stage mit einem  JDK  Basis-Container gebaut. In der vorherigen Stage  ist jedoch bereits eine jJr kompiliert worden, weshalb in dieser Stage eine JRE reicht.Dadurch sollte das finale Image kleiner werden und weniger enthalten (z.b. kein JDK)